### PR TITLE
download_hash was spelled incorrectly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class riak(
   $version = hiera('version', $riak::params::version),
   $package = hiera('package', $riak::params::package),
   $download = hiera('download', $riak::params::download),
-  $doanload_hash = hiera('download_hash', $riak::params::download_hash),
+  $download_hash = hiera('download_hash', $riak::params::download_hash),
   $source = hiera('source', ''),
   $template = hiera('template', ''),
   $architecture = hiera('architecture', $riak::params::architecture),


### PR DESCRIPTION
I am using my own URLs for Riak RPMs and I noticed the download_hash param was spelled incorrectly.
