### PR TITLE
Fix namespace collision

### DIFF
--- a/lib/puppet/parser/util/merger.rb
+++ b/lib/puppet/parser/util/merger.rb
@@ -25,7 +25,7 @@ module Puppet::Parser::Util
       # union merge all items of kvs2
       } | kvs2.reject { |k, v| kvs1.has_key? k }.to_a
 
-      Hash[ merged ]
+      ::Hash[ merged ]
     end
     def is_hashish? thing
       return false if thing.nil?


### PR DESCRIPTION
On subsequent runs after a puppetmaster restart I was seeing:

 Error: Could not retrieve catalog from remote server: Error 400 on SERVER: undefined method `[]' for Puppet::Parser::Util::Hash:Class at /etc/puppet/env/common/module/riak/manifests/appconfig.pp:36 on node $node.$domain

Appeared to be caused by a collision with the Hash class in Puppet::Parser::Util::InstanceMethods.
