### PR TITLE
Use $package variable in package resource when using httpfile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,7 +173,7 @@ class riak (
       require => Anchor['riak::start'],
       before  => Anchor['riak::end'],
     }
-    package { 'riak':
+    package { $package:
       ensure   => $manage_package,
       source   => $pkgfile,
       provider => $riak::params::package_provider,

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -33,7 +33,7 @@ describe 'riak', :type => :class do
           :path => '/tmp/custom_riak-1.2.0.deb',
           :hash => 'abcd' })
     end
-    it { should contain_package('riak').
+    it { should contain_package('custom_riak').
         with({
           :ensure => 'installed',
           :source =>'/tmp/custom_riak-1.2.0.deb'}) }


### PR DESCRIPTION
In my previous fix for the `package` resource name I missed the `package` when using `httpfile`. I am actually using Riak EE and using our custom provided package and it was failing. This should fix that scenario.

Note: There were already two unit tests failing and I am not sure how to fix them yet:

```
Failures:

  1) riak::vmargs at baseline defaults
     Failure/Error: }) }
     Puppet::Error:
       Duplicate declaration: Class[Riak::Vmargs] is already declared; cannot redeclare at /Users/ashinn/Projects/puppet-riak/spec/fixtures/modules/riak/manifests/init.pp:225 on node andys-macbook.local
     # ./spec/classes/vmargs_spec.rb:18:in `block (3 levels) in <top (required)>'

  2) riak::vmargs when decommissioning w/ params (absent):
     Failure/Error: it { should contain_file('/etc/riak/vm.args').with_ensure('absent') }
     Puppet::Error:
       Duplicate declaration: Class[Riak::Vmargs] is already declared; cannot redeclare at /Users/ashinn/Projects/puppet-riak/spec/fixtures/modules/riak/manifests/init.pp:225 on node andys-macbook.local
     # ./spec/classes/vmargs_spec.rb:35:in `block (3 levels) in <top (required)>'
```

But I did update the test for the `riak` class custom package name.
