### PR TITLE
add support for managing version of riak installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,18 @@ class riak (
     default => 'installed',
   }
 
+  # if $version is supplied then manage version of riak when installed via
+  # repository (unless we're uninstalling it)
+  case $version ? {
+    /[0-9]/: {
+      $riak_pkg_ensure = $manage_package ? {
+        'installed' => $version,
+        default     => $manage_package,
+      }
+    }
+    default: { $riak_pkg_ensure = $manage_package }
+  }
+
   $manage_repos_real = $use_repos ? {
     true    => $manage_repos,
     default => false
@@ -157,7 +169,7 @@ class riak (
 
   if $use_repos == true {
     package { $package:
-      ensure  => $manage_package,
+      ensure  => $riak_pkg_ensure,
       require => [
         Class[riak::config],
         Package[$riak::params::deps],


### PR DESCRIPTION
Useful for locking current version of riak for new nodes being added to an existing cluster.

There was another feature branch that I saw (package-version) that just applied $version to riaks dependencies as well as riak itself, which obviously isn't going to work. I assume that branch only working as $deps is an empty array by default.
