### PR TITLE
Fixed invalid "case" syntax

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,7 +115,7 @@ class riak (
 
   # if $version is supplied then manage version of riak when installed via
   # repository (unless we're uninstalling it)
-  case $version ? {
+  case $version {
     /[0-9]/: {
       $riak_pkg_ensure = $manage_package ? {
         'installed' => $version,


### PR DESCRIPTION
On line 118 its both a case statement and a ? selector and it caused
error. Removed the "?" selector.
