### PR TITLE
Restore links that were removed in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ bumps in the road.
    This issue affects a single test that exposed the issue; overriding
    puppet variables with rspec variables. The test is currently marked as
    pending.
+
+
+
+[1]: http://basho.com/
+[2]: https://github.com/basho/puppet-riak/wiki
+[3]: https://github.com/basho/puppet-riak/wiki/Testing-with-Vagrant


### PR DESCRIPTION
The footnote-style hyperlinks that used to be present in the README stopped working when they were trimmed out in this file's previous commit (probably in error).
