### PR TITLE
Fix idempotence of symlink creation in Rakefile spec_prep task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ task :spec_prep do
 
   FileUtils::mkdir_p("spec/fixtures/modules")
   fixtures("symlinks").each do |source, target|
-    File::exists?(target) || FileUtils::ln_s(source, target)
+    FileUtils.ln_s(source, target) unless File.symlink?(target)
   end
 
   FileUtils::mkdir_p("tests/data") unless File.exists? "tests/data"


### PR DESCRIPTION
The presence of a symlink was being tested with File.exists?, but this was not 
reliable in my own testing.  I changed it to File.symlink?, which I hope 
reflects the intent.
