### PR TITLE
Making Package['curl'] compatible if it is already defined somewhere els...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,8 +39,10 @@ class riak::config (
           path    => '/etc/apt/sources.list.d/basho.list',
           content => "deb http://apt.basho.com ${$::lsbdistcodename} main\n",
         }
-        package { 'curl':
-          ensure => installed,
+        if ! defined(Package['curl']) {
+          package { 'curl':
+            ensure => installed,
+          }
         }
         exec { 'add-basho-key':
           command => '/usr/bin/curl http://apt.basho.com/gpg/basho.apt.key | /usr/bin/apt-key add -',


### PR DESCRIPTION
In case that Package['curl'] is already defined somewhere else, this would generate an error.

  Error 400 on SERVER: Duplicate declaration: Package[curl] is already declared in file $foo.

To avoid this error, Package['$name'] should only match, if needed.
