### PR TITLE
Add parameter vmargs_source and vmargs_template to the main init.pp file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,14 @@
 # template:
 #   Sets the content of the content parameter for the main configuration file
 #
+# vmargs_source:
+#   Sets the content of source parameter for vm.args configuration file
+#   If defined, riak's vm.args file will have the param: source => $source.
+#   Mutually exclusive with $vmargs_template.
+#
+# vmargs_template:
+#   Sets the content of the content parameter for the vm.args configuration file
+#
 # architecture:
 #   What architecture to fetch/run on
 #
@@ -83,6 +91,8 @@ class riak (
   $download_hash       = hiera('download_hash', $riak::params::download_hash),
   $source              = hiera('source', ''),
   $template            = hiera('template', ''),
+  $vmargs_source       = hiera('vmargs_source', ''),
+  $vmargs_template     = hiera('vmargs_template', ''),
   $architecture        = hiera('architecture', $riak::params::architecture),
   $log_dir             = hiera('log_dir', $riak::params::log_dir),
   $erl_log_dir         = hiera('erl_log_dir', $riak::params::erl_log_dir),
@@ -227,6 +237,8 @@ class riak (
 
   class { 'riak::vmargs':
     absent  => $absent,
+    source   => $vmargs_source,
+    template => $vmargs_template,
     cfg     => $vmargs_cfg,
     require => [
       File[$etc_dir],

--- a/manifests/vmargs.pp
+++ b/manifests/vmargs.pp
@@ -14,8 +14,8 @@
 class riak::vmargs (
   $cfg         = {},
   $erl_log_dir = hiera('erl_log_dir', $riak::params::erl_log_dir),
-  $template    = hiera('vm_args_template', ''),
   $source      = hiera('vm_args_source', ''),
+  $template    = hiera('vm_args_template', ''),
   $absent      = false,
 ) inherits riak::params {
 


### PR DESCRIPTION
I added two parameters to the main module. This should allow the possibility of specifying either a source file or a template for the vm.args configuration file. The vmargs.pp file already handle that, but is was never used (it only checks for $vmargs_cfg).
