### PR TITLE
Allow ulimits to be managed externally

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,8 +7,9 @@
 # a "status" parameter, yet.  Working around that for now.
 
 class riak::config (
-  $absent       = false,
-  $manage_repos = true,
+  $absent        = false,
+  $manage_repos  = true,
+  $manage_ulimit = true,
 ) {
   $ulimit = $riak::ulimit
   $limits_template = $riak::limits_template
@@ -68,10 +69,12 @@ class riak::config (
     }
   }
 
-  file { '/etc/security/limits.conf':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '644',
-    content => template($limits_template)
+  if $manage_ulimit == true {
+    file { '/etc/security/limits.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '644',
+      content => template($limits_template)
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,12 @@
 # package_hash:
 #   A URL of a hash-file or sha2-string in hexdigest
 #
+# manage_ulimit:
+#   If +true+ it will try to install a template and set the ulimits for the
+#   riak user in /etc/security/limits.conf. If you manage this file in another
+#   module then you should set this to +false+ and ensure you set appropriate
+#   limits for riak as per riak::params::ulimit
+#
 # manage_repos:
 #   If +true+ it will try to setup the repositories provided by basho.com to
 #   install Riak. If you manage your own repositories for whatever reason you
@@ -88,6 +94,7 @@ class riak (
   $download            = hiera('download', $riak::params::download),
   $use_repos           = hiera('use_repos', $riak::params::use_repos),
   $manage_repos        = hiera('manage_repos', true),
+  $manage_ulimit       = hiera('manage_ulimit', true),
   $download_hash       = hiera('download_hash', $riak::params::download_hash),
   $source              = hiera('source', ''),
   $template            = hiera('template', ''),
@@ -229,10 +236,11 @@ class riak (
   }
 
   class { 'riak::config':
-    absent       => $absent,
-    manage_repos => $manage_repos_real,
-    require      => Anchor['riak::start'],
-    before       => Anchor['riak::end'],
+    absent        => $absent,
+    manage_repos  => $manage_repos_real,
+    manage_ulimit => $manage_ulimit,
+    require       => Anchor['riak::start'],
+    before        => Anchor['riak::end'],
   }
 
   class { 'riak::vmargs':


### PR DESCRIPTION
I like to manage my /etc/security/limits.conf file for my servers (as
it's not specific to riak) via another method.

This commit makes it possible to disable the riak module's default
behaviour of trying to manage the /etc/security/limits.conf file, which
will cause a resource conflict if also defined in another module.
