### PR TITLE
allow setting the ip to listen on

### DIFF
--- a/manifests/appconfig.pp
+++ b/manifests/appconfig.pp
@@ -39,14 +39,14 @@ class riak::appconfig(
       inet_dist_listen_max => 7999,
     },
     riak_api  => {
-      pb_ip   => $::ipaddress,
+      pb_ip   => $riak::ip,
       pb_port => 8087,
     },
     riak_core => {
       ring_state_dir     => "${$riak::params::data_dir}/ring",
       ring_creation_size => 64,
       http               => {
-        "__string_${$::ipaddress}" => 8098,
+        "__string_${$riak::ip}" => 8098,
       },
       handoff_port      => 8099,
       dtrace_support    => false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,9 @@
 # architecture:
 #   What architecture to fetch/run on
 #
+# ip:
+#   What ip address to listen on
+#
 # == Requires
 #
 # * stdlib (module)
@@ -112,6 +115,7 @@ class riak (
   $etc_dir             = hiera('etc_dir', $riak::params::etc_dir),
   $data_dir            = hiera('data_dir', $riak::params::data_dir),
   $service_autorestart = hiera('service_autorestart', $riak::params::service_autorestart),
+  $ip                  = hiera('ip', $::ipaddress),
   $cfg                 = hiera_hash('cfg', {}),
   $vmargs_cfg          = hiera_hash('vmargs_cfg', {}),
   $disable             = false,

--- a/manifests/vmargs.pp
+++ b/manifests/vmargs.pp
@@ -20,9 +20,9 @@ class riak::vmargs (
 ) inherits riak::params {
 
   $vmargs_cfg = merge({
-    '-name'      => "riak@${::ipaddress}",
+    '-name'      => "riak@${riak::ip}",
     '-setcookie' => 'riak',
-    '-ip'        => $::ipaddress,
+    '-ip'        => $riak::ip,
     '+K'         => true,
     '+A'         => 64,
     '-smp'       => 'enable',


### PR DESCRIPTION
Add new argument 'riak::ip' in order to explicitly set the ip riak services listen on. The previous value of $::ipaddress is rather brittle as it amounts to: ip that's first parsed from ifconfig and doesn't match ^127. 

Old behaviour is preserved by using $::ipaddress as default. 

I was unable to run the spec tests by following the documentation. End result on every test was:

```
Error from DataBinding 'hiera' while looking up 'riak::version': FileSystem implementation expected Pathname, got: 'Hash'
```

Testing in vagrant showed the desired changes with no regressions however.
