### PR TITLE
RPM spec file overrides puppet configuration

### DIFF
--- a/manifests/appconfig.pp
+++ b/manifests/appconfig.pp
@@ -152,6 +152,8 @@ class riak::appconfig(
     ensure  => $manage_file,
     content => $manage_template,
     source  => $manage_source,
+    owner   => 'riak',
+    group   => 'riak',
     require => [
       File["${$appcfg[riak_core][platform_log_dir]}"],
       File["${$appcfg[riak_core][platform_lib_dir]}"],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,6 +238,7 @@ class riak (
     template => $template,
     cfg      => $cfg,
     require  => [
+      Package[$package],
       File[$etc_dir],
       Anchor['riak::start'],
     ],
@@ -260,6 +261,7 @@ class riak (
     template => $vmargs_template,
     cfg     => $vmargs_cfg,
     require => [
+      Package[$package],
       File[$etc_dir],
       Anchor['riak::start'],
     ],
@@ -270,7 +272,10 @@ class riak (
   group { 'riak':
     ensure => present,
     system => true,
-    require => Anchor['riak::start'],
+    require => [
+      Package[$package],
+      Anchor['riak::start'],
+    ],
     before  => Anchor['riak::end'],
   }
 

--- a/manifests/vmargs.pp
+++ b/manifests/vmargs.pp
@@ -53,6 +53,8 @@ class riak::vmargs (
     ensure  => $manage_file,
     content => $manage_template,
     source  => $manage_source,
+    owner   => 'riak',
+    group   => 'riak',
     require => Anchor['riak::vmargs::start'],
     before  => Anchor['riak::vmargs::end'],
   }


### PR DESCRIPTION
- user home configuration gets overwritten by rpm spec file
- files ownership is incorrect
