### PR TITLE
Release 0.2.0 to the Forge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,3 @@
-YYYY-MM-DD Release 0.1.0
-- something you did
-- something else you did
+2015-3-30 Release 0.2.0
+- Rewrite for Riak 2
+- Require puppet 3.7 and future parser

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'basholabs-riak'
-version       '0.1.0'
+version       '0.2.0'
 source        'github.com/basho-labs/puppet-riak'
 author        'basholabs'
 license       'Apache 2.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "basholabs-riak",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "basholabs",
   "summary": "Manage Riak 2.x",
   "license": "Apache-2.0",


### PR DESCRIPTION
This just updates everything to the 0.2.0 version. I like to make a symbolic PR before doing releases so that the release process can go through the PR review process. Once this is merged I'll publish this exact tag to Puppet Forge.