### PR TITLE
Add performance tuning for ulimits

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,4 +14,17 @@ class riak::config {
     notify  => Service[$::riak::service_name],
     before  => Service[$::riak::service_name],
   }
+  # set ulimits max file handles
+  riak::tuning::limits {
+    "${::riak::params::riak_user}-soft":
+      user    => $::riak::params::riak_user,
+      type    => soft,
+      item    => nofile,
+      value   => $::riak::ulimits_nofile_soft;
+    "${::riak::params::riak_user}-hard":
+      user    => $::riak::params::riak_user,
+      type    => hard,
+      item    => nofile,
+      value   => $::riak::ulimits_nofile_hard;
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,13 +8,13 @@
 #   Explanation of what this parameter affects and what it defaults to.
 #
 class riak (
-  String[1] $package_name = $::riak::params::package_name,
-  String[1] $service_name = $::riak::params::service_name,
-  Boolean $manage_package = $::riak::params::manage_package,
-  Boolean $manage_repo    = $::riak::params::manage_repo,
-  String[1] $version      = $::riak::params::version,
-  $ulimits_nofile_soft    = $::riak::params::ulimits_nofile_soft,
-  $ulimits_nofile_hard    = $::riak::params::ulimits_nofile_hard,
+  String[1] $package_name       = $::riak::params::package_name,
+  String[1] $service_name       = $::riak::params::service_name,
+  Boolean $manage_package       = $::riak::params::manage_package,
+  Boolean $manage_repo          = $::riak::params::manage_repo,
+  String[1] $version            = $::riak::params::version,
+  Integer $ulimits_nofile_soft  = $::riak::params::ulimits_nofile_soft,
+  Integer $ulimits_nofile_hard  = $::riak::params::ulimits_nofile_hard,
   Hash[String, Variant[String, Boolean, Integer]] $settings = {},
 ) inherits ::riak::params {
   if $manage_repo and $manage_package {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ class riak (
   Boolean $manage_package = $::riak::params::manage_package,
   Boolean $manage_repo    = $::riak::params::manage_repo,
   String[1] $version      = $::riak::params::version,
+  $ulimits_nofile_soft    = $::riak::params::ulimits_nofile_soft,
+  $ulimits_nofile_hard    = $::riak::params::ulimits_nofile_hard,
   Hash[String, Variant[String, Boolean, Integer]] $settings = {},
 ) inherits ::riak::params {
   if $manage_repo and $manage_package {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,16 @@
 # == Class: riak
 #
-# Full description of class riak here.
+# Desploy and manage Riak.
 #
 # === Parameters
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
+# [*$package_name*]
+# [*$service_name*]
+# [*$manage_package*]
+# [*$manage_repo*]
+# [*$version*]
+# [*$ulimits_nofile_soft*]
+# [*$ulimits_nofile_hard*]
 #
 class riak (
   String[1] $package_name       = $::riak::params::package_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # == Class: riak
 #
-# Desploy and manage Riak.
+# Deploy and manage Riak.
 #
 # === Parameters
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,8 @@ class riak::params {
   $riak_user           = 'riak'
   $riak_group          = 'riak'
   $ulimits_context     = '/files/etc/security/limits.conf'
-  $ulimits_nofile_soft = '65536'
-  $ulimits_nofile_hard = '65536'
+  $ulimits_nofile_soft = 65536
+  $ulimits_nofile_hard = 65536
   $default_settings = {
     'anti_entropy'                      => 'active',
     'bitcask.data_root'                 => '$(platform_data_dir)/bitcask',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,12 +4,15 @@
 # It sets variables according to platform.
 #
 class riak::params {
-  $version          = 'present' # setting to latest could result in uplanned upgrades
-  $manage_repo      = true
-  $manage_package   = true
-  $riak_conf        = '/etc/riak/riak.conf'
-  $riak_user        = 'riak'
-  $riak_group       = 'riak'
+  $version             = 'present' # setting to latest could result in uplanned upgrades
+  $manage_repo         = true
+  $manage_package      = true
+  $riak_conf           = '/etc/riak/riak.conf'
+  $riak_user           = 'riak'
+  $riak_group          = 'riak'
+  $ulimits_context     = '/files/etc/security/limits.conf'
+  $ulimits_nofile_soft = '65536'
+  $ulimits_nofile_hard = '65536'
   $default_settings = {
     'anti_entropy'                      => 'active',
     'bitcask.data_root'                 => '$(platform_data_dir)/bitcask',

--- a/manifests/repository/debian.pp
+++ b/manifests/repository/debian.pp
@@ -8,7 +8,6 @@ class riak::repository::debian {
   apt::source { 'riak':
     location   => 'https://packagecloud.io/basho/riak/debian/',
     key        => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-    key_source => 'https://packagecloud.io/gpg.key',
     pin        => '550',
     repos      => 'main',
     release    => $::lsbdistcodename,

--- a/manifests/tuning.pp
+++ b/manifests/tuning.pp
@@ -1,8 +1,8 @@
 # Set ulimits max open files
 #
 define riak::tuning::limits (
-    String[1] $user, String[1] $type, String[1] $item, Integer $value
-  ) {
+  String[1] $user, String[1] $type, String[1] $item, Integer $value
+) {
 
   $key = "$user/$type/$item"
   $path_list  = "domain[.=\"$user\"][./type=\"$type\" and ./item=\"$item\"]"

--- a/manifests/tuning.pp
+++ b/manifests/tuning.pp
@@ -1,6 +1,8 @@
 # Set ulimits max open files
 #
-define riak::tuning::limits ($user, $type, $item, $value) {
+define riak::tuning::limits (
+    String[1] $user, String[1] $type, String[1] $item, Integer $value
+  ) {
 
   $key = "$user/$type/$item"
   $path_list  = "domain[.=\"$user\"][./type=\"$type\" and ./item=\"$item\"]"

--- a/manifests/tuning.pp
+++ b/manifests/tuning.pp
@@ -1,0 +1,20 @@
+# Set ulimits max open files
+#
+define riak::tuning::limits ($user, $type, $item, $value) {
+
+  $key = "$user/$type/$item"
+  $path_list  = "domain[.=\"$user\"][./type=\"$type\" and ./item=\"$item\"]"
+  $path_match = "domain[.=\"$user\"][./type=\"$type\" and ./item=\"$item\" and ./value=\"$value\"]"
+
+  augeas { "limits_conf/$key":
+    context => $::riak::ulimits_context,
+    onlyif  => "match $path_match size != 1",
+    changes => [
+      "rm $path_list",
+      "set domain[last()+1] $user",
+      "set domain[last()]/type $type",
+      "set domain[last()]/item $item",
+      "set domain[last()]/value $value",
+      ],
+  }
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,7 +6,7 @@ shared_examples_for "a running riak service" do
 
   describe service('riak') do
     it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
+    it { is_expected.to be_running riak hard nofile }
   end
 
   describe port(8087) do
@@ -63,6 +63,10 @@ describe 'riak class' do
 
     it_behaves_like "a running riak service"
     it_behaves_like "riak self-tests"
+
+    describe file('/etc/security/limits.conf') do
+      its(:content) { should contain /riak hard nofile 65536/ } # default setting
+    end
   end
 
   context 'with config parameters set' do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,7 +6,6 @@ shared_examples_for "a running riak service" do
 
   describe service('riak') do
     it { is_expected.to be_enabled }
-    it { is_expected.to be_running riak hard nofile }
   end
 
   describe port(8087) do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,6 +6,7 @@ shared_examples_for "a running riak service" do
 
   describe service('riak') do
     it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
   end
 
   describe port(8087) do
@@ -64,7 +65,8 @@ describe 'riak class' do
     it_behaves_like "riak self-tests"
 
     describe file('/etc/security/limits.conf') do
-      its(:content) { should contain /riak hard nofile 65536/ } # default setting
+      its(:content) { should contain /riak hard nofile 65536/ }
+      its(:content) { should contain /riak soft nofile 65536/ }
     end
   end
 

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -3,8 +3,8 @@ HOSTS:
     roles:
       - master
     platform: el-7-x86_64
-    box: chef/centos-7.0
-    box_url: https://vagrantcloud.com/chef/boxes/centos-7.0
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 
 CONFIG:

--- a/spec/acceptance/nodesets/debian-610-x64.yml
+++ b/spec/acceptance/nodesets/debian-610-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-610-x64:
+    roles:
+      - master
+    platform: debian-6-amd64
+    box: puppetlabs/debian-6.0.10-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-6.0.10-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -108,4 +108,5 @@ describe 'riak' do
       it { expect { is_expected.to contain_package('riak') }.to raise_error(Puppet::Error, /plan9 not supported/) }
     end
   end
+
 end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -24,20 +24,15 @@ describe 'riak' do
           it { is_expected.to contain_class('riak::config') }
           it { is_expected.to contain_package('riak').with_ensure('present') }
           it { is_expected.to contain_service('riak') }
-          # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
-          # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 65536/) }
-
           case facts[:osfamily]
-            when 'RedHat'
-              it { is_expected.to contain_class('riak::repository::el') }
-              it { is_expected.to contain_yumrepo('basho_riak') }
-            when 'Debian'
-              it { is_expected.to contain_class('riak::repository::debian') }
-              it { is_expected.to contain_apt__source('riak') }
+          when 'RedHat'
+            it { is_expected.to contain_class('riak::repository::el') }
+            it { is_expected.to contain_yumrepo('basho_riak') }
+          when 'Debian'
+            it { is_expected.to contain_class('riak::repository::debian') }
+            it { is_expected.to contain_apt__source('riak') }
           end
-
         end
-
         context "riak class with repositories disabled" do
           let(:params) {{
             :manage_repo => false
@@ -58,7 +53,6 @@ describe 'riak' do
             it { is_expected.to_not contain_apt__source('riak') }
           end
         end
-
         context "riak class with package set to specific version" do
           let(:params) {{
             :version => '2.0.5'
@@ -66,7 +60,6 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_package('riak').with_ensure('2.0.5') }
         end
-
         context "riak class with package install disabled" do
           let(:params) {{
             :manage_package => false
@@ -75,7 +68,6 @@ describe 'riak' do
           it { is_expected.to_not contain_package('riak') }
           it { is_expected.to_not contain_class('riak::install') }
         end
-
         context "riak class with custom package name" do
           let(:params) {{
             :package_name => 'ermongo'
@@ -83,7 +75,6 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_package('ermongo') }
         end
-
         context "riak class with custom service name" do
           let(:params) {{
             :service_name => 'ermongo'
@@ -91,7 +82,6 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_service('ermongo') }
         end
-
         context "riak class with custom config settings" do
           let(:params) {{
             :settings => {
@@ -103,7 +93,6 @@ describe 'riak' do
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
         end
-
       end
     end
   end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -93,6 +93,7 @@ describe 'riak' do
           }}
           it_behaves_like "class required behavior"
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
+           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
         end
       end
     end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -93,7 +93,7 @@ describe 'riak' do
           }}
           it_behaves_like "class required behavior"
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
-           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
+          it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
         end
       end
     end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -5,7 +5,6 @@ shared_examples_for "class required behavior" do
   it { is_expected.to contain_class('riak::params') }
   it { is_expected.to contain_class('riak::service').that_subscribes_to('riak::config') }
   it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/nodename = riak@/) }
-  # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
 end
 
 describe 'riak' do
@@ -94,17 +93,6 @@ describe 'riak' do
           }}
           it_behaves_like "class required behavior"
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
-          it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(
-            /dtrace = on/) }
-        # context "riak class with custom config settings" do
-        #   let(:params) {{
-        #     :ulimits_nofile_soft => 8000,
-        #     :ulimits_nofile_hard => 9000,
-        #   }}
-        #   it_behaves_like "class required behavior"
-        #   it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 8000/) }
-        #   it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 9000/) }
-        #   end
         end
       end
     end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -5,6 +5,7 @@ shared_examples_for "class required behavior" do
   it { is_expected.to contain_class('riak::params') }
   it { is_expected.to contain_class('riak::service').that_subscribes_to('riak::config') }
   it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/nodename = riak@/) }
+  # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
 end
 
 describe 'riak' do
@@ -17,6 +18,8 @@ describe 'riak' do
 
         context "riak class without any parameters" do
           let(:params) {{ }}
+
+          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
 
           it_behaves_like "class required behavior"
 
@@ -91,7 +94,17 @@ describe 'riak' do
           }}
           it_behaves_like "class required behavior"
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
-          it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
+          it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(
+            /dtrace = on/) }
+        # context "riak class with custom config settings" do
+        #   let(:params) {{
+        #     :ulimits_nofile_soft => 8000,
+        #     :ulimits_nofile_hard => 9000,
+        #   }}
+        #   it_behaves_like "class required behavior"
+        #   it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 8000/) }
+        #   it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 9000/) }
+        #   end
         end
       end
     end

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 shared_examples_for "class required behavior" do
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to contain_class('riak') }

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -24,8 +24,8 @@ describe 'riak' do
           it { is_expected.to contain_class('riak::config') }
           it { is_expected.to contain_package('riak').with_ensure('present') }
           it { is_expected.to contain_service('riak') }
-          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
-          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 65536/) }
+          # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
+          # it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 65536/) }
 
           case facts[:osfamily]
             when 'RedHat'

--- a/spec/classes/riak_spec.rb
+++ b/spec/classes/riak_spec.rb
@@ -18,23 +18,26 @@ describe 'riak' do
         context "riak class without any parameters" do
           let(:params) {{ }}
 
-          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
-
           it_behaves_like "class required behavior"
 
           it { is_expected.to contain_class('riak::install') }
           it { is_expected.to contain_class('riak::config') }
           it { is_expected.to contain_package('riak').with_ensure('present') }
           it { is_expected.to contain_service('riak') }
+          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak hard nofile 65536/) }
+          it { is_expected.to contain_file('/etc/security/limits.conf').with_content(/riak soft nofile 65536/) }
+
           case facts[:osfamily]
-          when 'RedHat'
-            it { is_expected.to contain_class('riak::repository::el') }
-            it { is_expected.to contain_yumrepo('basho_riak') }
-          when 'Debian'
-            it { is_expected.to contain_class('riak::repository::debian') }
-            it { is_expected.to contain_apt__source('riak') }
+            when 'RedHat'
+              it { is_expected.to contain_class('riak::repository::el') }
+              it { is_expected.to contain_yumrepo('basho_riak') }
+            when 'Debian'
+              it { is_expected.to contain_class('riak::repository::debian') }
+              it { is_expected.to contain_apt__source('riak') }
           end
+
         end
+
         context "riak class with repositories disabled" do
           let(:params) {{
             :manage_repo => false
@@ -55,6 +58,7 @@ describe 'riak' do
             it { is_expected.to_not contain_apt__source('riak') }
           end
         end
+
         context "riak class with package set to specific version" do
           let(:params) {{
             :version => '2.0.5'
@@ -62,6 +66,7 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_package('riak').with_ensure('2.0.5') }
         end
+
         context "riak class with package install disabled" do
           let(:params) {{
             :manage_package => false
@@ -70,6 +75,7 @@ describe 'riak' do
           it { is_expected.to_not contain_package('riak') }
           it { is_expected.to_not contain_class('riak::install') }
         end
+
         context "riak class with custom package name" do
           let(:params) {{
             :package_name => 'ermongo'
@@ -77,6 +83,7 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_package('ermongo') }
         end
+
         context "riak class with custom service name" do
           let(:params) {{
             :service_name => 'ermongo'
@@ -84,6 +91,7 @@ describe 'riak' do
           it_behaves_like "class required behavior"
           it { is_expected.to contain_service('ermongo') }
         end
+
         context "riak class with custom config settings" do
           let(:params) {{
             :settings => {
@@ -95,6 +103,7 @@ describe 'riak' do
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/foo = bar/) }
           it { is_expected.to contain_file('/etc/riak/riak.conf').with_content(/dtrace = on/) }
         end
+
       end
     end
   end

--- a/tests/tuning_config.pp
+++ b/tests/tuning_config.pp
@@ -1,0 +1,15 @@
+# This sets some (basically random) configuration settings to validate that
+# the module generates valid config files
+class { '::riak':
+  package_name        => 'riak',
+  service_name        => 'riak',
+  manage_package      => true,
+  manage_repo         => true,
+  version             => 'latest',
+  ulimits_nofile_soft => 88536,
+  ulimits_nofile_hard => 98536,
+  settings            => {
+    'log.syslog'                 => 'on',
+    'listener.protobuf.internal' => "${::ipaddress}:8087"
+  },
+}


### PR DESCRIPTION
This change adds ulimits performance tuning whereby the maximum open file handles is increased by adding `riak hard nofile` and `riak soft nofile` in  `/etc/security/limits.conf.` When running with default values the config file will be modified like so:

`riak hard nofile 65536`
`riak soft nofile 65536`

Custom values can be set by the user by passing parameters like this:

    class { '::riak':
      ulimits_nofile_soft => 88536,
      ulimits_nofile_hard => 98536,
    }