### PR TITLE
Change box to puppetlabs/centos-7.0-64-nocm.

### DIFF
--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -3,8 +3,8 @@ HOSTS:
     roles:
       - master
     platform: el-7-x86_64
-    box: chef/centos-7.0
-    box_url: https://vagrantcloud.com/chef/boxes/centos-7.0
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 
 CONFIG:


### PR DESCRIPTION
The previous config used a box that would fail compilation of the guest additions and thus could not mount a drive on the guest OS and would fail Beaker tests.

This config works with Vagrant 1.7.2 and VirtualBox 4.3.26.
