### PR TITLE
Remove key_source parameter to match change in puppetlabs-apt

### DIFF
--- a/manifests/repository/debian.pp
+++ b/manifests/repository/debian.pp
@@ -8,7 +8,6 @@ class riak::repository::debian {
   apt::source { 'riak':
     location   => 'https://packagecloud.io/basho/riak/debian/',
     key        => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-    key_source => 'https://packagecloud.io/gpg.key',
     pin        => '550',
     repos      => 'main',
     release    => $::lsbdistcodename,

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -3,8 +3,8 @@ HOSTS:
     roles:
       - master
     platform: el-7-x86_64
-    box: chef/centos-7.0
-    box_url: https://vagrantcloud.com/chef/boxes/centos-7.0
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 
 CONFIG:


### PR DESCRIPTION
Redoing as a separate PR only containing this fix. This removes the `key_source` parameter. Without this change rspec tests are failing due to a change in the puppetlabs-apt module. This change will allow rspec tests to pass.