### PR TITLE
Update docs and changelog, and bump version to 0.2.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2015-5-22 Release 0.2.3
+- Enable performance tuning of ulimits (per-user open file limit)
+- Update repo management for Debian to match change in puppetlabs-apt
+- Update docs
 2015-3-30 Release 0.2.0
 - Rewrite for Riak 2
 - Require puppet 3.7 and future parser

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Overview
 
-This module manages the 2.x versions of the Riak distributed key-value store. 
+This module manages the 2.x versions of the Riak distributed key-value store.
 
 [Riak](http://basho.com/riak/) is an open source, distributed database that
 focuses on high availability, horizontal scalability, and *predictable*
@@ -81,6 +81,58 @@ class { '::riak':
 }
 ```
 
+A configuration with custom performance tuning.
+
+Increase the per-user open files limit (ulimits):
+
+```puppet
+class { '::riak':
+  ulimits_nofile_soft => 88536,
+  ulimits_nofile_hard => 98536,
+}
+```
+
+## Reference
+
+###Parameters
+
+The following parameters are available in the `::riak` class:
+
+####`package_name`
+
+Name of the Riak package to install.
+Default: `riak`
+
+####`service_name`
+
+Name of the Riak service.
+Default: `riak`
+
+####`manage_package`
+
+Whether to install the Riak package.
+Default: `true`
+
+####`manage_repo`
+
+Whether to setup and enable the remote yum or apt package repos from which Riak will be installed. The repo is hosted at [packagecloud.io.](https://packagecloud.io) If you set this to `false` the Riak packages will need to be present in your existing package repos.
+Default: `true`
+
+####`version`
+
+The version of Riak to manage. Set the package version if desired.
+Default: `present` (Setting to latest could result in unplanned upgrades.)
+
+####`ulimits_nofile_soft`
+
+Set per-user open files soft limit in `/etc/security/limits.conf`
+Default: `65536`
+
+####`ulimits_nofile_hard`
+
+Set per-user open files hard limit in `/etc/security/limits.conf`
+Default: `65536`
+
 ## Limitations
 
 This module is only expected to work with:
@@ -113,7 +165,7 @@ are signed, so this only applies to EL platforms.
 
 ## Development
 
-Basho Labs repos survive because of community contribution. This module has extensive test coverage in order to make contributing easier. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details. 
+Basho Labs repos survive because of community contribution. This module has extensive test coverage in order to make contributing easier. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ### Maintainers
 * Hendrik Feldt ([GitHub](https://github.com/haf))

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,16 +2,6 @@
 #
 # Deploy and manage Riak.
 #
-# === Parameters
-#
-# [*$package_name*]
-# [*$service_name*]
-# [*$manage_package*]
-# [*$manage_repo*]
-# [*$version*]
-# [*$ulimits_nofile_soft*]
-# [*$ulimits_nofile_hard*]
-#
 class riak (
   String[1] $package_name       = $::riak::params::package_name,
   String[1] $service_name       = $::riak::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 # It sets variables according to platform.
 #
 class riak::params {
-  $version             = 'present' # setting to latest could result in uplanned upgrades
+  $version             = 'present' # setting to latest could result in unplanned upgrades
   $manage_repo         = true
   $manage_package      = true
   $riak_conf           = '/etc/riak/riak.conf'

--- a/manifests/tuning.pp
+++ b/manifests/tuning.pp
@@ -1,4 +1,8 @@
-# Set ulimits max open files
+# == Class riak::tuning
+#
+# This class tunes the system for performance.
+# see http://docs.basho.com/riak/latest/ops/tuning/linux/
+# for descriptions of these settings
 #
 define riak::tuning::limits (
   String[1] $user, String[1] $type, String[1] $item, Integer $value

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "basholabs-riak",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "basholabs",
   "summary": "Manage Riak 2.x",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR is for updates to documentation only, including README.md, CHANGELOG and metadata.json. This brings the docs in line with the performance tuning recently added in `tuning.pp`.  I also updated to version 0.2.3 to push the version for the performance tuning changes. Please comment if this version change is out of line.