### PR TITLE
Make management of the sudo package optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ class { '::riak':
   service_name   => 'riak',   # default
   manage_package => true,     # default
   manage_repo    => true,     # default
+  manage_sudo    => true,     # default
   version        => 'latest', # default, use a package version if desired
   # settings in the settings hash are written directly to settings.conf.
   settings       => {
@@ -116,6 +117,11 @@ Default: `true`
 ####`manage_repo`
 
 Whether to setup and enable the remote yum or apt package repos from which Riak will be installed. The repo is hosted at [packagecloud.io.](https://packagecloud.io) If you set this to `false` the Riak packages will need to be present in your existing package repos.
+Default: `true`
+
+####`manage_sudo`
+
+Whether to ensure the "sudo" package is installed.
 Default: `true`
 
 ####`version`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class riak (
   String[1] $service_name       = $::riak::params::service_name,
   Boolean $manage_package       = $::riak::params::manage_package,
   Boolean $manage_repo          = $::riak::params::manage_repo,
+  Boolean $manage_sudo          = $::riak::params::manage_sudo,
   String[1] $version            = $::riak::params::version,
   Integer $ulimits_nofile_soft  = $::riak::params::ulimits_nofile_soft,
   Integer $ulimits_nofile_hard  = $::riak::params::ulimits_nofile_hard,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,9 @@
 # This class is called from riak for install.
 #
 class riak::install {
-  ensure_packages(['sudo'])
+  if $::riak::manage_sudo {
+    ensure_packages(['sudo'])
+  }
   package { $::riak::package_name:
     ensure => $::riak::version,
     before => Service[$::riak::service_name],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class riak::params {
   $version             = 'present' # setting to latest could result in unplanned upgrades
   $manage_repo         = true
   $manage_package      = true
+  $manage_sudo         = true
   $riak_conf           = '/etc/riak/riak.conf'
   $riak_user           = 'riak'
   $riak_group          = 'riak'

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -79,6 +79,7 @@ describe 'riak class' do
         service_name   => 'riak',
         manage_package => true,
         manage_repo    => true,
+        manage_sudo    => true,
         version        => 'latest',
         settings       => {
           'log.syslog'                              => 'on',

--- a/tests/basic_config.pp
+++ b/tests/basic_config.pp
@@ -16,6 +16,7 @@ class { '::riak':
   service_name   => 'riak',
   manage_package => true,
   manage_repo    => true,
+  manage_sudo    => true,
   version        => 'latest',
   settings       => {
     'log.syslog'                 => 'on',

--- a/tests/tuning_config.pp
+++ b/tests/tuning_config.pp
@@ -5,6 +5,7 @@ class { '::riak':
   service_name        => 'riak',
   manage_package      => true,
   manage_repo         => true,
+  manage_sudo         => true,
   version             => 'latest',
   ulimits_nofile_soft => 88536,
   ulimits_nofile_hard => 98536,


### PR DESCRIPTION
Some environments such as ours use the [sudo-ldap](https://packages.debian.org/jessie/sudo-ldap) package to allow sudo auth against company ldap servers. The riak module currently breaks this by installing the "sudo" package, which in Debian land (and presumably [Ubuntu](http://packages.ubuntu.com/search?keywords=sudo-ldap) as well) conflicts with and removes the sudo-ldap package.

This pull request adds a "manage_sudo" parameter, set to true by default, which allows us to prevent puppet-riak from installing sudo.

I realise this is somewhat of an edge case and you may want to avoid cluttering the interface to init.pp, so if you have a better place for it I'm happy to refactor it, but looking at the existing layout it seemed most logical to put it beside manage_package and manage_repo.

Or if you feel this is too niche to clutter up the interface fair enough, I'm happy to maintain a patch just figured it would be easiest if it was included upstream.

Thanks for providing this module!
