### PR TITLE
Increase apt compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "version_requirement": ">= 1.0.0 <3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Tested that version 2 is also working and added it to the manifest.

Version 1.X is already outdated by far. 